### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in this repo.
+* @pinecone-io/dev-advocates @pinecone-io/sdk

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -43,7 +43,7 @@ jobs:
         run: npx playwright install --with-deps
       - name: Run Playwright tests
         run: npx playwright test
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
Adds a CODEOWNERS file so review requests route to the owning team(s). Opened as part of onboarding `pinecone-io/pinecone-rag-demo` into the groundskeeper maintenance fleet. A human reviews and merges.