### PR TITLE
fix: harden ESLint and Next.js config resolution

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,7 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  // Pin the workspace root so a parent-directory lockfile can't hijack it.
+  outputFileTracingRoot: __dirname,
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
**PR 2 of 4** — stacked on #40.

Two independent config-resolution fixes:

- **`.eslintrc.json`: add `"root": true`.** Without it, ESLint cascades *upward* into ancestor-directory configs. In a checkout nested under another repo (e.g. a git worktree) it picks up an ancestor `.eslintrc` and fails with `Failed to load config "next/core-web-vitals"`. `root: true` is standard hardening every project config should have.
- **`next.config.js`: set `outputFileTracingRoot` to the project dir** so a parent-directory lockfile can't be auto-selected as the workspace root (silences the multi-lockfile warning and stabilizes root detection).

No dependency or behavior changes.