### PR TITLE
ci: pin pnpm to 10 so dependency install works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 10
       - uses: actions/setup-node@v7
         with:
           node-version: 20


### PR DESCRIPTION
**PR 0 of the stack** — standalone fix for the currently-red CI on `main`.

`main`'s CI `build` job runs pnpm **9**, which cannot read the `overrides` in `pnpm-workspace.yaml` (pnpm 10+ only) and fails `pnpm install` with:

```
ERROR  packages field missing or empty
```

The last CI run on `main` is already failing for this reason. This bumps the CI to pnpm **10**, matching `playwright.yml`. One-line change; mergeable on its own.

The rest of the stack (#40–#43) is rebased on top of this so their installs succeed.