### PR TITLE
security: remediate open Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-markdown": "^9.0.1",
     "react-spinners": "^0.14.1",
     "sswr": "^2.1.0",
-    "svelte": "^4.2.19",
+    "svelte": "^5.55.7",
     "tailwindcss": "3.4.11",
     "typescript": "5.6.2",
     "unified": "^11.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ overrides:
   yaml: ^2.8.1
   sharp: ^0.35.0
   solid-js: ^1.9.4
-  svelte: ^5.51.5
+  svelte: ^5.55.7
 
 importers:
 
@@ -107,7 +107,7 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(svelte@5.56.8)
       svelte:
-        specifier: ^5.51.5
+        specifier: ^5.55.7
         version: 5.56.8
       tailwindcss:
         specifier: 3.4.11
@@ -206,7 +206,7 @@ packages:
     resolution: {integrity: sha512-gV0MhaWxkatjf7uJrCAHO3bWrihokNUwGhuMCgyG+y53lwJKAYhR0zCoDRM2HnTJ89fdnx/PVe3R9fOWEVY5qA==}
     engines: {node: '>=18'}
     peerDependencies:
-      svelte: ^5.51.5
+      svelte: ^5.55.7
     peerDependenciesMeta:
       svelte:
         optional: true
@@ -1337,7 +1337,7 @@ packages:
       openai: ^4.42.0
       react: ^18 || ^19
       sswr: ^2.1.0
-      svelte: ^5.51.5
+      svelte: ^5.55.7
       zod: ^3.0.0
     peerDependenciesMeta:
       openai:
@@ -3695,7 +3695,7 @@ packages:
   sswr@2.1.0:
     resolution: {integrity: sha512-Cqc355SYlTAaUt8iDPaC/4DPPXK925PePLMxyBKuWd5kKc5mwsG3nT9+Mq2tyguL5s7b4Jg+IRMpTRsNTAfpSQ==}
     peerDependencies:
-      svelte: ^5.51.5
+      svelte: ^5.55.7
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,7 +30,7 @@ overrides:
   # Unused framework adapters pulled in transitively by ai@3; patched to clear
   # their XSS advisories without affecting this React-only app.
   solid-js: '^1.9.4'
-  svelte: '^5.51.5'
+  svelte: '^5.55.7'
 
 # sharp ships prebuilt binaries; allow its install script so next/image
 # optimization works at runtime.


### PR DESCRIPTION
## Summary

Clears the **6 medium `svelte` Dependabot alerts** with a minimal, safe change. `svelte` is an **unused** framework adapter pulled in transitively by `ai@3` (this is a React/Next.js app — no `svelte` imports in `src/` or `tests/`).

The `pnpm` overrides in `pnpm-workspace.yaml` already forced the installed `svelte` to a patched 5.x (**5.56.8**), but `package.json` still declared `svelte: ^4.2.19`, which Dependabot reads as falling inside the vulnerable `<= 5.55.6` range and keeps flagging.

**Fix:** bump the direct dep to `^5.55.7` (at/above the latest patched version) and raise the override floor from `^5.51.5` to `^5.55.7` to match. **The installed version is unchanged (5.56.8)** — no runtime or build behavior changes; this only realigns the manifest so Dependabot stops flagging.

## Alerts fixed

| Advisory | Package | Severity | How |
| --- | --- | --- | --- |
| #92, #90 (`<= 5.55.6`) | svelte | medium | direct dep `^4.2.19` → `^5.55.7` |
| #53 (`<= 5.53.4`) | svelte | medium | direct dep `^4.2.19` → `^5.55.7` |
| #48, #45, #44 (`<= 5.51.4`) | svelte | medium | direct dep `^4.2.19` → `^5.55.7` |

## Deferred (per remediation policy — require the `ai` 3 → 5 major bump)

| Advisory | Package | Severity | Reason |
| --- | --- | --- | --- |
| #20, #19 | ai | low | Filetype whitelist bypass; patched only in `ai` 5.0.52. Breaking major (`ai` 3 → 5) — tracked in Dependabot PR #21, needs its own regression pass. |
| #107 | @ai-sdk/provider-utils | low | Uncontrolled resource consumption; **no patched version published** (`first_patched_version` is null). Pulled in via `ai@3`; only escaped by moving to the `ai` 5 line. |

## Local verification (pnpm 10, matching CI)

All green:

| Check | Command | Result |
| --- | --- | --- |
| Lint | `pnpm run lint` | pass (no warnings/errors) |
| Type-check | `pnpm run typecheck` | pass |
| Unit tests | `pnpm run test:coverage` | pass (9 suites, 44 tests) |
| Build | `pnpm run build` | pass |
| Audit gate | `pnpm audit --audit-level high` | pass (0 high/critical) |
| Frozen install | `pnpm install --frozen-lockfile` | pass (lockfile up to date) |

`pnpm audit` residuals after this PR: 2 low + 1 moderate — the two deferred `ai`/`@ai-sdk/provider-utils` lows above, plus a pre-existing **dev-only** `ajv` (ReDoS) moderate that requires `eslint` 8 → 9 (already documented in `SECURITY-NOTES.md`). None are high/critical, so the CI audit gate stays green.

## Notes

- Diff is intentionally minimal: `package.json`, `pnpm-workspace.yaml`, and the 5 corresponding `svelte` specifier lines in `pnpm-lock.yaml`. Resolved dependency graph is unchanged.
- CI already exists (`ci.yml` build/lint/typecheck/test + audit gate, `playwright.yml`); no workflow changes in this PR.
