### PR TITLE
ci: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` to `pinecone-rag-demo`, which previously had no Dependabot coverage. Weekly, grouped minor/patch updates for **npm** (covers the pnpm lockfile) and **github-actions**.

The repo already has a strong CI setup — lint, typecheck, jest with coverage, build, a `pnpm audit` gate, and a separate Playwright e2e workflow — so this fills the one remaining standard-bar gap (automated dependency updates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)